### PR TITLE
Clean .travis.yml and add MacOS (.dmg) builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
     - os: linux
       env: CC=gcc-4.8 CXX=g++-4.8
       dist: trusty
+    - os: osx
+      osx_image: xcode10.1
+      env: CC=clang CXX=clang++ SIGN_BUILD=true
 
 script:
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: true
-
 git:
   submodules: false
 
@@ -29,7 +27,7 @@ addons:
       - libxkbfile-dev
       - curl
 
-matrix:
+jobs:
   include:
     - os: linux
       env: CC=gcc-4.8 CXX=g++-4.8
@@ -49,7 +47,7 @@ cache:
     - app/node_modules
 
 deploy:
-  skip_cleanup: true
+  cleanup: false
   provider: script
   script: bash scripts/deploy.sh
   on:


### PR DESCRIPTION
1. Adds MacOS/OSX builds back to Travis CI,
2. Removes matrix alias: "matrix" -> "jobs",
3. Updates to use "cleanup: false" instead of "skip_cleanup: true",
4. Removes deprecated use of "sudo".