### PR TITLE
Add windows builds to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,27 @@ addons:
 jobs:
   include:
     - os: linux
+      name: Linux Build
       env: CC=gcc-4.8 CXX=g++-4.8
       dist: trusty
+      script:
+        - npm run lint
+        - npm run postinstall
+        - DEBUG=electron-packager,electron-osx-sign npm run build
     - os: osx
+      name: macOS Build
       osx_image: xcode10.1
       env: CC=clang CXX=clang++ SIGN_BUILD=true
-
-script:
-  - npm run lint
-  - npm run postinstall
-  - DEBUG=electron-packager,electron-osx-sign npm run build
+      script:
+        - npm run lint
+        - npm run postinstall
+        - DEBUG=electron-packager,electron-osx-sign npm run build
+    - os: windows
+      name: Windows Build
+      script:
+        - powershell npm config set msvs_version 2015
+        - powershell npm install && powershell npm run build
+        - powershell node app/build/create-windows-installer.js
 
 cache:
   directories:
@@ -49,6 +60,8 @@ cache:
 deploy:
   skip_cleanup: true
   provider: script
-  script: bash scripts/deploy.sh
+  script:
+    - language: bash
+    - bash scripts/deploy.sh
   on:
     branch: master

--- a/app/build/create-windows-installer.js
+++ b/app/build/create-windows-installer.js
@@ -21,6 +21,7 @@ const config = {
   authors: 'Foundry 376, LLC',
   setupIcon: path.join(appDir, 'build', 'resources', 'win', 'mailspring.ico'),
   setupExe: 'MailspringSetup.exe',
+  setupMsi: 'MailspringSetup.msi',
   exe: 'mailspring.exe',
   name: 'Mailspring',
 };

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,8 @@
 
 shopt -s nullglob
 cd app/dist/
-for f in *.{dmg,zip,deb,rpm}; do
+ls
+for f in *.{dmg,zip,deb,rpm,msi}; do
   curl -F "fileToUpload=@$f" -F 'reqtype=fileupload' 'https://catbox.moe/user/api.php'
   printf "\n"
 done


### PR DESCRIPTION
New outputs:
- MailspringSetup.msi

Changes:
- Travis configuration: updated to include Windows
- Travis configuration: each OS is run with unique settings
- Adds named MailspringSetup.msi which is now uploaded to Catbox like other zip, dmg, deb, and rpm files).

My notes:
- Using one platform for Linux, macOS, and Windows builds is probably preferred
- Catbox doesn't allow direct .exe uploads, which is why I added the .msi file to be uploaded
- The .exe installation executable is still created
- The Windows installation executables are not signed, like the current macOS releases
- If we end up configuring something like automatic GitHub releases, we can still use the MailspringSetup.exe if we want. Or, maybe there is an alternative to Catbox which allows for .exe uploads