### PR TITLE
Add CSS to enable sticky send button during email compose

### DIFF
--- a/app/internal_packages/composer/styles/composer.less
+++ b/app/internal_packages/composer/styles/composer.less
@@ -283,6 +283,11 @@ body.platform-win32 {
     box-shadow: inset 0 2px 1px rgba(0, 0, 0, 0.03);
     border-bottom: 0;
     border-radius: @border-radius-base;
+    // Sticky send button
+    position: sticky;
+    bottom: 0;
+    overflow: visible;
+    z-index: 3; // Display on top of rich text editing bar
 
     .action-bar-cover-gen;
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2640,9 +2640,9 @@
           "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "prebuild-install": {
           "version": "2.5.3",
@@ -2652,7 +2652,7 @@
             "detect-libc": "1.0.3",
             "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
+            "minimist": "1.2.5",
             "mkdirp": "0.5.1",
             "node-abi": "2.8.0",
             "noop-logger": "0.1.1",


### PR DESCRIPTION
In response to #24 , I've adjusted the CSS to allow for a sticky bar with the send button that stays within the email being composed.

This is my first pull request (ever!) so if there's some extra work or testing I need to do, let me know! Happy to be able to contribute!