### PR TITLE
Add keybinding option to go to trash

### DIFF
--- a/app/internal_packages/preferences/lib/tabs/keymaps/displayed-keybindings.ts
+++ b/app/internal_packages/preferences/lib/tabs/keymaps/displayed-keybindings.ts
@@ -81,6 +81,7 @@ export default [
       ['navigation:go-to-starred', localized('Go to %@', localized('Starred'))],
       ['navigation:go-to-sent', localized('Go to %@', localized('Sent Mail'))],
       ['navigation:go-to-drafts', localized('Go to %@', localized('Drafts'))],
+      ['navigation:go-to-trash', localized('Go to %@', localized('Trash'))],
       ['navigation:go-to-all', localized('Go to %@', localized('All Mail'))],
     ],
   },

--- a/app/keymaps/templates/Apple Mail.json
+++ b/app/keymaps/templates/Apple Mail.json
@@ -9,6 +9,7 @@
   "navigation:go-to-contacts": "command+ctrl+6",
   "navigation:go-to-tasks": "command+ctrl+7",
   "navigation:go-to-label": "command+ctrl+8",
+  "navigation:go-to-trash": "command+ctrl+9",
 
   "multiselect-list:select-all": "command+a",
 

--- a/app/keymaps/templates/Gmail.json
+++ b/app/keymaps/templates/Gmail.json
@@ -7,6 +7,7 @@
   "navigation:go-to-contacts": "g c",
   "navigation:go-to-tasks": "g k",
   "navigation:go-to-label": "g l",
+  "navigation:go-to-trash": "g x",
 
   "multiselect-list:select-all": "* a",
   "multiselect-list:deselect-all": "* n",

--- a/app/menus/darwin.js
+++ b/app/menus/darwin.js
@@ -128,6 +128,7 @@ module.exports = {
         { label: localized('Go to %@', localized('Starred')), command: 'navigation:go-to-starred' },
         { label: localized('Go to %@', localized('Sent Mail')), command: 'navigation:go-to-sent' },
         { label: localized('Go to %@', localized('Drafts')), command: 'navigation:go-to-drafts' },
+        { label: localized('Go to %@', localized('Trash')), command: 'navigation:go-to-trash' },
         { label: localized('Go to %@', localized('All Mail')), command: 'navigation:go-to-all' },
         { type: 'separator' },
         { label: localized('Enter Full Screen'), command: 'window:toggle-full-screen' },

--- a/app/menus/linux.js
+++ b/app/menus/linux.js
@@ -98,6 +98,7 @@ module.exports = {
         { label: localized('Go to %@', localized('Starred')), command: 'navigation:go-to-starred' },
         { label: localized('Go to %@', localized('Sent Mail')), command: 'navigation:go-to-sent' },
         { label: localized('Go to %@', localized('Drafts')), command: 'navigation:go-to-drafts' },
+        { label: localized('Go to %@', localized('Trash')), command: 'navigation:go-to-trash' },
         { label: localized('Go to %@', localized('All Mail')), command: 'navigation:go-to-all' },
         { type: 'separator' },
         { label: localized('Enter Full Screen'), command: 'window:toggle-full-screen' },

--- a/app/menus/win32.js
+++ b/app/menus/win32.js
@@ -75,6 +75,7 @@ module.exports = {
         { label: localized('Go to %@', localized('Starred')), command: 'navigation:go-to-starred' },
         { label: localized('Go to %@', localized('Sent Mail')), command: 'navigation:go-to-sent' },
         { label: localized('Go to %@', localized('Drafts')), command: 'navigation:go-to-drafts' },
+        { label: localized('Go to %@', localized('Trash')), command: 'navigation:go-to-trash' },
         { label: localized('Go to %@', localized('All Mail')), command: 'navigation:go-to-all' },
         { type: 'separator' },
         { label: localized('Enter Full Screen'), command: 'window:toggle-full-screen' },

--- a/app/src/flux/stores/focused-perspective-store.ts
+++ b/app/src/flux/stores/focused-perspective-store.ts
@@ -50,6 +50,7 @@ class FocusedPerspectiveStore extends MailspringStore {
         const categories = this._current.accountIds.map(id => CategoryStore.getArchiveCategory(id));
         this._setPerspective(MailboxPerspective.forCategories(categories));
       },
+      'navigation:go-to-trash': () => this._setPerspectiveByName('trash'),
       'navigation:go-to-contacts': () => {}, // TODO,
       'navigation:go-to-tasks': () => {}, // TODO,
       'navigation:go-to-label': () => {}, // TODO,


### PR DESCRIPTION
Similar to being able to navigate to the inbox or drafts folder, this commit allows binding a key to navigate to the trash.

I created this PR becuase I had a need for the functionality. I use the Trash folder to put mail into automatically which is admin in nature. I understand that my use case is not anyone elses use case however it sites alongside existing functionality well so here it is.

Full disclosure, I don't use Gmail and so do not know if this makes sense in that contact. I made the defualt bindings up based on the other keybindings. Apple Mail doesn't have this binding at all for example. I also don't know if a Trash folder is common to all mail accounts or just mine so it might not work everywhere. It seems to fail silently though so no harm done?

Happy to take feedback and rejection well :) 

