### PR TITLE
add libglib2-bin as alternative to gvfs-bin

### DIFF
--- a/app/build/resources/linux/debian/control.in
+++ b/app/build/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: libsecret-1-dev, git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python | python2, gvfs-bin, xdg-utils
+Depends: libsecret-1-dev, git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python | python2, gvfs-bin | libglib2.0-bin, xdg-utils
 Suggests: gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional


### PR DESCRIPTION
Cherry-picked https://github.com/Foundry376/Mailspring/pull/2220/commits/c4f7b7f277063141e77e0355aa8b16ea4503cd37, this should fix #45. We should also update to [1.8.0](https://github.com/Foundry376/Mailspring/releases/tag/1.8.0) (released a week ago) sometime.